### PR TITLE
Fix task section width on current_member page

### DIFF
--- a/current_member.html
+++ b/current_member.html
@@ -579,14 +579,14 @@
                     </div>
                 </div>
             </div>
-        </div>
-        <div class="task-section">
-            <h3 class="task-title">任務小組委員推薦詳情</h3>
-            <div class="task-buttons">
-                <a href="medhum_updated.html" class="detail-button">查看醫學人文委員推薦詳情</a>
-                <a href="cbme_committee_page.html" class="detail-button">查看CBME委員推薦詳情</a>
-                <a href="digital_committee_list.html" class="detail-button">查看數位賦能委員推薦詳情</a>
-                <a href="cfd_structure_updated.html" class="detail-button">查看師資培育委員推薦詳情</a>
+            <div class="task-section">
+                <h3 class="task-title">任務小組委員推薦詳情</h3>
+                <div class="task-buttons">
+                    <a href="medhum_updated.html" class="detail-button">查看醫學人文委員推薦詳情</a>
+                    <a href="cbme_committee_page.html" class="detail-button">查看CBME委員推薦詳情</a>
+                    <a href="digital_committee_list.html" class="detail-button">查看數位賦能委員推薦詳情</a>
+                    <a href="cfd_structure_updated.html" class="detail-button">查看師資培育委員推薦詳情</a>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- place the task group recommendation block inside the content container so it lines up with the qualification section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b2203cbdc832184c07ff9450b8437