### PR TITLE
Update back button style on teacher training page

### DIFF
--- a/cfd_structure_updated.html
+++ b/cfd_structure_updated.html
@@ -45,14 +45,17 @@
             color: #fff;
             text-decoration: none;
             padding: 8px 16px;
-            background: linear-gradient(45deg, #667eea, #764ba2);
+            background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
             border-radius: 20px;
             font-size: 0.9rem;
-            transition: background 0.3s;
+            box-shadow: 0 4px 15px rgba(102, 126, 234, 0.2);
+            z-index: 1;
+            transition: background 0.3s, box-shadow 0.3s;
         }
 
         .back-button:hover {
-            background: rgba(255, 255, 255, 0.9);
+            background: linear-gradient(135deg, #c3cfe2 0%, #f5f7fa 100%);
+            box-shadow: 0 6px 20px rgba(102, 126, 234, 0.3);
         }
 
         .header h1 {


### PR DESCRIPTION
## Summary
- tweak the "返回首頁" button on the 師資培育 page to use the same soft purple/gray palette
- keep the button size consistent with the digital page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b29946b308321895810fee706f175