### PR TITLE
Fix back button visibility on teacher training page

### DIFF
--- a/cfd_structure_updated.html
+++ b/cfd_structure_updated.html
@@ -43,6 +43,7 @@
             left: 20px;
             top: 20px;
             color: #fff;
+            -webkit-text-fill-color: white;
             text-decoration: none;
             padding: 8px 16px;
             background: #7A6ACB;


### PR DESCRIPTION
## Summary
- ensure the 師資培育 back button text displays in white

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685b98c06bfc832186622ca5a1adcab8