### PR TITLE
Refine recommend section colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,16 +175,21 @@
         }
 
         .recommend-card {
-            background: linear-gradient(135deg, #e0c3fc 0%, #8ec5fc 100%);
+            background: linear-gradient(135deg, #FFF2DC 0%, #FFE1CC 100%);
         }
 
         .recommend-card::before {
-            background: linear-gradient(45deg, #a1c4fd, #c2e9fb);
+            background: linear-gradient(45deg, #FFBC7D, #F58D6D);
         }
 
         .recommend-card .recommend-title {
-            background: linear-gradient(135deg, #a1c4fd 0%, #c2e9fb 100%);
+            background: linear-gradient(135deg, #FFBC7D 0%, #F58D6D 100%);
             color: white;
+        }
+
+        .recommend-card .description {
+            background: #ffffff;
+            color: #000000;
         }
 
         .legend {


### PR DESCRIPTION
## Summary
- apply warm beige gradient to the recommend section card
- switch card header gradient to soft orange hues
- ensure recommend description uses white background and black text

## Testing
- `xmllint --html --noout index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ba3aba70c8321b37fc7d93876702f