### PR TITLE
Add narrative award page with music button

### DIFF
--- a/narrative_award.html
+++ b/narrative_award.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>敘事醫學競賽獲獎</title>
+    <style>
+        body {
+            font-family: 'Microsoft JhengHei', Arial, sans-serif;
+            background: linear-gradient(135deg, #f0f9ff, #bae6fd);
+            text-align: center;
+            padding-top: 50px;
+        }
+        .music-btn {
+            background: linear-gradient(135deg, #2196F3, #1976D2);
+            border: none;
+            color: white;
+            padding: 15px 25px;
+            font-size: 1.5rem;
+            border-radius: 30px;
+            cursor: pointer;
+            box-shadow: 0 4px 10px rgba(33,150,243,0.3);
+        }
+    </style>
+</head>
+<body>
+    <h1>敘事醫學競賽獲獎</h1>
+    <audio id="awardAudio" src="/audio/award-fanfare.mp3" style="display:none"></audio>
+    <button id="playBtn" class="music-btn">♫</button>
+
+    <script>
+        const audio = document.getElementById('awardAudio');
+        document.getElementById('playBtn').addEventListener('click', () => {
+            audio.play();
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new page for "敘事醫學競賽獲獎" with a music button
- music button plays `/audio/award-fanfare.mp3` and hides the audio controls
- music note icon displays in white against original background

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c6b1372588321896ba421a17fae9a